### PR TITLE
Remove examples map IDs

### DIFF
--- a/Mapbox-iOS-SDK/Headers/RMMapboxSource.h
+++ b/Mapbox-iOS-SDK/Headers/RMMapboxSource.h
@@ -39,7 +39,7 @@
 #define kMapboxDefaultLatLonBoundingBox ((RMSphericalTrapezium){ .northEast = { .latitude =  90, .longitude =  180 }, \
                                                                  .southWest = { .latitude = -90, .longitude = -180 } })
 
-#define kMapboxPlaceholderMapID @"examples.map-z2effxa8"
+#define kMapboxPlaceholderMapID @"mapbox.streets"
 
 // constants for the image quality API (see https://www.mapbox.com/developers/api/maps/#format)
 typedef enum : NSUInteger {

--- a/Swiftbox/ViewController.swift
+++ b/Swiftbox/ViewController.swift
@@ -1,12 +1,12 @@
 import UIKit
 
 class ViewController: UIViewController {
-                            
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         RMConfiguration.sharedInstance().accessToken = "pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A"
-        let source = RMMapboxSource(mapID: "examples.map-z2effxa8")
+        let source = RMMapboxSource(mapID: "mapbox.streets")
         let map = RMMapView(frame: view.bounds, andTilesource: source)
         map.zoom = 16
         map.centerCoordinate = CLLocationCoordinate2D(latitude: 38.913175, longitude: -77.032458)


### PR DESCRIPTION
Removes `examples` map IDs and replaces them with `mapbox.streets`. cc @incanus @friedbunny 